### PR TITLE
Replace __defineSetter__ and __defineGetter__ with Object.defineProperty

### DIFF
--- a/src/firmin.js
+++ b/src/firmin.js
@@ -30,18 +30,18 @@ Firmin.CSSMatrix = (typeof WebKitCSSMatrix == 'object')
  **/
 Firmin.prefix = (function() {
     var test     = document.createElement("div"),
-        prefixes = ["webkit", "Moz", "O"],
-        i        = 3,
-        prefix;
-    
+       prefixes = ["webkit", "Moz", "O", "ms"],
+       i        = 4,
+       prefix;
+
     while (i--) {
-        prefix = prefixes[i];
-        test.style.cssText = "-" + prefix.toLowerCase() +
-            "-transition-property:opacity;";
-        if (typeof test.style[prefix + "TransitionProperty"] != "undefined")
-            return prefix;
+       prefix = prefixes[i];
+       test.style.cssText = "-" + prefix.toLowerCase() +
+           "-transform-origin: 0 0;";
+       if (typeof test.style[prefix + "TransformOrigin"] != "undefined")
+           return prefix;
     }
-    
+
     return prefix;
 })();
 

--- a/src/matrix.js
+++ b/src/matrix.js
@@ -229,12 +229,13 @@ FirminCSSMatrix.determinant4x4 = function(m) {
  ["m42", "f"]].forEach(function(pair) {
     var key3d = pair[0], key2d = pair[1];
     
-    FirminCSSMatrix.prototype.__defineSetter__(key2d, function(val) {
-        this[key3d] = val;
-    });
-    
-    FirminCSSMatrix.prototype.__defineGetter__(key2d, function() {
-        return this[key3d];
+    Object.defineProperty(FirminCSSMatrix.prototype, key2d, {
+      set: function(val) {
+          this[key3d] = val;
+      },
+      get: function() {
+          return this[key3d];
+      }
     });
 });
 


### PR DESCRIPTION
The __define\* methods are depreciated in ES5. Additionally, Object.defineProperty has much wider browser support, including, at least, ie9.
